### PR TITLE
update to 0.12.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-# To define `MAP_ANONYMOUS`
-MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - "10.11"          # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,9 @@ source:
 
 build:
   skip: true  # [python_impl == 'pypy']
-  script: |
-    {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - set CMAKE_GENERATOR=Ninja # [win]
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
@@ -25,6 +26,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.15  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
+    - ninja                               # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   skip: true  # [python_impl == 'pypy']
   script: |
-    {{ PYTHON }} -m pip install . -vv
+    {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   script_env:   # [win]
     # Unset `CMAKE_GENERATOR` and let Visual Studio set to its default
@@ -24,16 +24,17 @@ requirements:
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
     - cmake >=3.15  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
   host:
     - pip
     - python
-    - pybind11 >=2.11.1
+    - setuptools
+    - wheel
+    - pybind11 2
   run:
     - python
-    - typing-extensions >=4.0.0
+    - typing-extensions >=4.5.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,8 @@ build:
   script: |
     {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  script_env:   # [win]
-    # Unset `CMAKE_GENERATOR` and let Visual Studio set to its default
-    - CMAKE_GENERATOR=  # [win]
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:


### PR DESCRIPTION
optree 0.12.1

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-5456
- https://github.com/metaopt/optree/tree/v0.12.1

### Explanation of changes:

- New feedstock, for keras
