### PR TITLE
optree 0.14.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,9 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  script_env:             # [win]
-    - CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
+  script_env:                    # [win]
+    - CMAKE_GENERATOR_PLATFORM=  # [win]
+    - CMAKE_GENERATOR=Ninja      # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 
@@ -25,6 +26,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.18  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
+    - ninja  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
 
 build:
-  skip: true  # [python_impl == 'pypy']
   script:
     - set CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -23,7 +22,7 @@ requirements:
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - {{ compiler('cxx') }}
-    - cmake >=3.15  # to support `CMAKE_GENERATOR`
+    - cmake >=3.18  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [python_impl == 'pypy']
   script:
-    - set CMAKE_GENERATOR=Ninja # [win]
+    - set CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   missing_dso_whitelist:  # [s390x]
@@ -25,7 +25,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.15  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
-    - ninja-base                          # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:           # [win]
     # Unset `CMAKE_GENERATOR_PLATFORM` and let Visual Studio set to its default
-    - set CMAKE_GENERATOR_PLATFORM=  # [win]
+    - CMAKE_GENERATOR_PLATFORM=  # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:           # [win]
-    # Unset `CMAKE_GENERATOR` and let Visual Studio set to its default
-    - CMAKE_GENERATOR=  # [win]
+    # Unset `CMAKE_GENERATOR_PLATFORM` and let Visual Studio set to its default
+    - set CMAKE_GENERATOR_PLATFORM=  # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,12 @@ source:
   sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
 
 build:
-  script:
-    - set CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
-    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script_env:           # [win]
+    # Unset `CMAKE_GENERATOR` and let Visual Studio set to its default
+    - CMAKE_GENERATOR=  # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,8 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  script_env:           # [win]
-    # Unset 'CMAKE_GENERATOR' and let Visual Studio set to its default
-    - CMAKE_GENERATOR=  # [win]
+  script_env:             # [win]
+    - CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:           # [win]
-    # Unset `CMAKE_GENERATOR_PLATFORM` and let Visual Studio set to its default
-    - CMAKE_GENERATOR_PLATFORM=  # [win]
+    # Unset 'CMAKE_GENERATOR' and let Visual Studio set to its default
+    - CMAKE_GENERATOR=  # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,16 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
+  # Download the github source because of a missing tests/helpers.py file in the sdist
+  - url: https://github.com/metaopt/optree/archive/refs/tags/v0.14.1.tar.gz
+    sha256: 904fc4f5ca53512e65347c8f31b0dda292c4a24530de4e227e6202c94ddfcfe3
+    folder: gh
 
 build:
   number: 0
+  skip: True  # [py<38]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:             # [win]
@@ -30,7 +35,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - pybind11 2
+    - pybind11 >=2.12
   run:
     - python
     - typing-extensions >=4.5.0
@@ -38,10 +43,18 @@ requirements:
 test:
   imports:
     - optree
-  commands:
-    - pip check
+  source_files:
+    - tests
+    - gh/tests/helpers.py
   requires:
     - pip
+    - pytest
+    - pytest-xdist
+  commands:
+    - pip check
+    - cp gh/tests/helpers.py tests
+    # test_treespec_pickle_missing_registration fails with AssertionError, see https://github.com/metaopt/optree/issues/199
+    - pytest tests -v -k "not test_treespec_pickle_missing_registration"
 
 about:
   home: https://github.com/metaopt/optree

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
   # Download the github source because of a missing tests/helpers.py file in the sdist
-  - url: https://github.com/metaopt/optree/archive/refs/tags/v0.14.1.tar.gz
+  - url: https://github.com/metaopt/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: 904fc4f5ca53512e65347c8f31b0dda292c4a24530de4e227e6202c94ddfcfe3
     folder: gh
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,8 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  script_env:                    # [win]
-    - CMAKE_GENERATOR_PLATFORM=  # [win]
-    - CMAKE_GENERATOR=Ninja      # [win]
+  script_env:             # [win]
+    - CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 
@@ -26,7 +25,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.18  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
-    - ninja  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "optree" %}
-{% set version = "0.12.1" %}
-{% set sha256 = "76a2240e7482355966a73c6c701e3d1f148420a77849c78d175d3b08bf06ff36" %}
+{% set version = "0.14.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
 
 build:
   skip: true  # [python_impl == 'pypy']
@@ -26,7 +25,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.15  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
-    - ninja                               # [win]
+    - ninja-base                          # [win]
   host:
     - pip
     - python
@@ -48,6 +47,7 @@ test:
 about:
   home: https://github.com/metaopt/optree
   summary: Optimized PyTree Utilities
+  description: Optimized PyTree Utilities.
   dev_url: https://github.com/metaopt/optree
   doc_url: https://optree.readthedocs.io
   license: Apache-2.0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7142](https://anaconda.atlassian.net/browse/PKG-7142)
- [Upstream repo](https://github.com/metaopt/optree/tree/v0.14.1)
- release-diff: https://github.com/metaopt/optree/compare/v0.12.1...v0.14.1
- changelog: https://github.com/metaopt/optree/blob/main/CHANGELOG.md
- requirements-tagged:
  - https://github.com/metaopt/optree/blob/v0.14.1/CMakeLists.txt
  - https://github.com/metaopt/optree/blob/v0.14.1/pyproject.toml
  - https://github.com/metaopt/optree/blob/v0.14.1/requirements.txt
  - https://github.com/metaopt/optree/blob/v0.14.1/setup.py


### Explanation of changes:

- Remove `ninja` from build on win and `set CMAKE_GENERATOR=Visual Studio 16 2019` to avoid the error `Generator Ninja does not support platform specification, but platform x64 was specified.`.
- Add description


[PKG-7142]: https://anaconda.atlassian.net/browse/PKG-7142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ