### PR TITLE
optree 0.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,13 +41,14 @@ test:
   imports:
     - optree
   source_files:
+    - pyproject.toml
     - tests
   requires:
     - pip
     - pytest
   commands:
     - pip check
-    - pytest -W always -W error tests
+    - pytest -Walways -Werror --showlocals tests
 
 about:
   home: https://github.com/metaopt/optree

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,22 @@
 {% set name = "optree" %}
-{% set version = "0.14.1" %}
+{% set version = "0.15.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: c011c6124d6dcbfceade2d7c4f836eab66ed8cf9ab12f94535b41a71dd734637
-  # Download the github source because of a missing tests/helpers.py file in the sdist
-  - url: https://github.com/metaopt/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 904fc4f5ca53512e65347c8f31b0dda292c4a24530de4e227e6202c94ddfcfe3
-    folder: gh
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d00a45e3b192093ef2cd32bf0d541ecbfc93c1bd73a5f3fe36293499f28a50cf
 
 build:
   number: 0
   skip: True  # [py<38]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  script_env:             # [win]
+  script_env:
     - CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
+    - _GLIBCXX_USE_CXX11_ABI=1
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 
@@ -45,16 +42,12 @@ test:
     - optree
   source_files:
     - tests
-    - gh/tests/helpers.py
   requires:
     - pip
     - pytest
-    - pytest-xdist
   commands:
     - pip check
-    - cp gh/tests/helpers.py tests
-    # test_treespec_pickle_missing_registration fails with AssertionError, see https://github.com/metaopt/optree/issues/199
-    - pytest tests -v -k "not test_treespec_pickle_missing_registration"
+    - pytest -W always -W error tests
 
 about:
   home: https://github.com/metaopt/optree

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:
-    - CMAKE_GENERATOR=Visual Studio 16 2019 # [win]
+    - CMAKE_GENERATOR=Ninja  # [win]
     - _GLIBCXX_USE_CXX11_ABI=1
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
@@ -27,6 +27,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.18  # to support `CMAKE_GENERATOR`
     - make                                # [not win]
+    - ninja                               # [win]
   host:
     - pip
     - python


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository](https://github.com/metaopt/optree/tree/v0.15.0)
- release-diff: [metaopt/optree@v0.14.1...v0.15.0](https://github.com/metaopt/optree/compare/v0.14.1...v0.15.0)
- changelog: [metaopt/optree@`main`/CHANGELOG.md](https://github.com/metaopt/optree/blob/main/CHANGELOG.md)

### Explanation of changes:

- Update version and source hash
- Update test commands