### PR TITLE
PKG-13552: rebuild optree against pybind11 3.0.4 (DO NOT MERGE — staging only)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314: yes
+# Dev/staging channel for pre-release pybind11 3.0.4 (PKG-13552) — this
+# rebuild needs the new pybind11 3.0.4 + pybind11-abi 11 from staging so
+# the resulting optree artifact pins pybind11-abi ==11 (not ==4). Remove
+# this `channels:` block once pybind11 3.0.4 ships to pkgs/main and the
+# pybind11-v3 migration is complete.
+channels:
+  - xkong-staging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
     sha256: 84b7e203b6e7196df76f4e651eaa3bc6ce0f30495facf434fea850eb4b92279d
 
 build:
-  number: 0
-  script_env: 
+  number: 1
+  script_env:
     - _GLIBCXX_USE_CXX11_ABI=1
     # Unset `CMAKE_GENERATOR` and let Visual Studio set to its default
     - CMAKE_GENERATOR=  # [win]


### PR DESCRIPTION
**Status:** staging/dev-channel build only. Will be revised or reverted once pybind11 3.0.4 lands on pkgs/main via the full PKG-13552 ecosystem migration. **DO NOT merge to master.**

**Destination channel:** none (PBP per-PR staging URL only)

### Links

- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) — pybind11 v3 migration epic
- [pybind11-feedstock #24](https://github.com/AnacondaRecipes/pybind11-feedstock/pull/24) — the pybind11 3.0.4 PR (open, in staging)
- Consumer: [pytorch-feedstock #97](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/97) — pytorch 2.12.0; needs optree built against pybind11 3.0.4 for tests to pass

### Why

Optree on pkgs/main is currently built against pybind11 2.x:

```
$ conda search 'optree=0.18.0=py313*' -c pkgs/main --override-channels --info
dependencies:
  - python >=3.13,<3.14.0a0
  - typing-extensions >=4.6.0
  - pybind11-abi ==4         ← pins to ABI 4
```

Pytorch 2.12 (PR #97) builds against pybind11 3.0.4 from xkong-staging and pins `pybind11-abi ==11`. The two abi versions cannot coexist in a test env:

```
LibMambaUnsatisfiableError: pytorch requires optree >=0.13.0, but none of
the providers can be installed.
  - pytorch 2.12.0 would require pybind11-abi ==11
  - optree 0.18.0 would require pybind11-abi ==4
  → solver gives up.
```

### What changes

- `recipe/meta.yaml` — build number `0 → 1` (no source change).
- `abs.yaml` — add `channels: [xkong-staging]` so PBP resolves pybind11 3.0.4 + pybind11-abi 11 from the staging channel at build time.
- `abs.yaml` — drop deprecated `ANACONDA_ROCKET_ENABLE_PY314: yes` (py3.14 is in aggregate CBC default since 2026-04).

The recipe's `pybind11 >=2.12` host pin already permits 3.x — no recipe change needed for the version itself. The resulting artifact will pin `pybind11-abi ==11` via run_export.

### After CI

Once PBP builds finish, the per-PR staging URL (`https://staging.continuum.io/pbp/fs/optree-feedstock/pr<N>/<sha>`) will be added to pytorch-feedstock #97's `abs.yaml` channels list, unblocking pytorch tests.

### Cleanup

Once pybind11 3.0.4 lands on pkgs/main and the full PKG-13552 migration completes:
- Either revert this PR (the regular migration rebuild supersedes), or
- Replace with a plain build-number bump if the regular migration produces an officially-abi-11-built optree.

[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ